### PR TITLE
Update requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ python-multipart
 psycopg2-binary
 alembic
 rich
+pydantic<2


### PR DESCRIPTION
A v2 do Pydantic alterou a especificação/api para customização de campo para ser usado no SQLModel, impedindo que o campo de senha seja salvo em hash no banco de dados.